### PR TITLE
Fix arbitrary item creation/NBT modification

### DIFF
--- a/src/main/kotlin/net/shadowfacts/clipboard/ItemClipboard.kt
+++ b/src/main/kotlin/net/shadowfacts/clipboard/ItemClipboard.kt
@@ -14,6 +14,7 @@ import net.shadowfacts.clipboard.block.TileEntityClipboard
 import net.shadowfacts.clipboard.gui.GUIClipboard
 import net.shadowfacts.clipboard.network.PacketUpdateClipboard
 import net.shadowfacts.clipboard.util.StackClipboard
+import net.shadowfacts.clipboard.util.Task
 import net.shadowfacts.shadowmc.ShadowMC
 import net.shadowfacts.shadowmc.item.ItemBase
 
@@ -43,8 +44,8 @@ class ItemClipboard : ItemBase("clipboard") {
 
 	@SideOnly(Side.CLIENT)
 	private fun openGUI(stack: ItemStack, player: EntityPlayer, hand: EnumHand) {
-		val synchronizer = {
-			Clipboard.network!!.sendToServer(PacketUpdateClipboard(stack, player, hand))
+		val synchronizer = { tasks: List<Task> ->
+			Clipboard.network!!.sendToServer(PacketUpdateClipboard(tasks, hand))
 		}
 		Minecraft.getMinecraft().displayGuiScreen(GUIClipboard.create(StackClipboard(stack), synchronizer))
 		player.swingArm(hand)

--- a/src/main/kotlin/net/shadowfacts/clipboard/block/BlockClipboard.kt
+++ b/src/main/kotlin/net/shadowfacts/clipboard/block/BlockClipboard.kt
@@ -22,6 +22,7 @@ import net.minecraftforge.fml.relauncher.SideOnly
 import net.shadowfacts.clipboard.Clipboard
 import net.shadowfacts.clipboard.gui.GUIClipboard
 import net.shadowfacts.clipboard.util.EntityItem
+import net.shadowfacts.clipboard.util.Task
 import net.shadowfacts.shadowmc.ShadowMC
 import net.shadowfacts.shadowmc.block.BlockTE
 import net.shadowfacts.shadowmc.network.PacketUpdateTE
@@ -83,7 +84,7 @@ class BlockClipboard : BlockTE<TileEntityClipboard>(Material.ROCK, "clipboard") 
 	@SideOnly(Side.CLIENT)
 	private fun openGUI(world: World, pos: BlockPos) {
 		val tile = getTileEntity(world, pos)
-		val synchronizer = {
+		val synchronizer = { tasks: List<Task> ->
 			ShadowMC.network.sendToServer(PacketUpdateTE(tile))
 		}
 		Minecraft.getMinecraft().displayGuiScreen(GUIClipboard.create(tile, synchronizer))

--- a/src/main/kotlin/net/shadowfacts/clipboard/gui/GUIClipboard.kt
+++ b/src/main/kotlin/net/shadowfacts/clipboard/gui/GUIClipboard.kt
@@ -21,11 +21,11 @@ object GUIClipboard {
 
 	val BG = ResourceLocation("clipboard", "textures/gui/clipboard.png")
 
-	fun create(clipboard: Clipboard, synchronize: () -> Unit): GuiScreen {
+	fun create(clipboard: Clipboard, synchronize: (tasks: List<Task>) -> Unit): GuiScreen {
 		val tasks = clipboard.getTasks()
 		val update = {
 			clipboard.setTasks(tasks)
-			synchronize()
+			synchronize(tasks)
 		}
 
 		return screen {

--- a/src/main/kotlin/net/shadowfacts/clipboard/network/HandlerUpdateClipboard.kt
+++ b/src/main/kotlin/net/shadowfacts/clipboard/network/HandlerUpdateClipboard.kt
@@ -1,9 +1,10 @@
 package net.shadowfacts.clipboard.network
 
-import net.minecraftforge.fml.common.FMLCommonHandler
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext
+import net.shadowfacts.clipboard.Clipboard
+import net.shadowfacts.clipboard.util.setTasks
 
 /**
  * @author shadowfacts
@@ -11,9 +12,11 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext
 class HandlerUpdateClipboard : IMessageHandler<PacketUpdateClipboard, IMessage> {
 
 	override fun onMessage(message: PacketUpdateClipboard, ctx: MessageContext?): IMessage? {
-		val player = FMLCommonHandler.instance().minecraftServerInstance.playerList.getPlayerByUUID(message.player)
+		val player = ctx!!.serverHandler.playerEntity
 		val stack = player.getHeldItem(message.hand)
-		stack!!.tagCompound = message.tag
+		if (stack.item == Clipboard.clipboard) {
+			stack.setTasks(message.tasks!!)
+		}
 		return null
 	}
 

--- a/src/main/kotlin/net/shadowfacts/clipboard/network/PacketUpdateClipboard.kt
+++ b/src/main/kotlin/net/shadowfacts/clipboard/network/PacketUpdateClipboard.kt
@@ -1,34 +1,36 @@
 package net.shadowfacts.clipboard.network
 
 import io.netty.buffer.ByteBuf
-import net.minecraft.entity.player.EntityPlayer
-import net.minecraft.item.ItemStack
-import net.minecraft.nbt.NBTTagCompound
 import net.minecraft.util.EnumHand
 import net.minecraftforge.fml.common.network.ByteBufUtils
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage
-import java.util.*
+import net.shadowfacts.clipboard.util.Task
 
 /**
  * @author shadowfacts
  */
-class PacketUpdateClipboard(var player: UUID?, var hand: EnumHand?, var tag: NBTTagCompound?) : IMessage {
+class PacketUpdateClipboard(var tasks: List<Task>?, var hand: EnumHand?) : IMessage {
 
-	constructor(stack: ItemStack, player: EntityPlayer, hand: EnumHand): this(player.uniqueID, hand, stack.tagCompound!!)
-
-	constructor(): this(null, null, null)
+	constructor(): this(null, null)
 
 	override fun toBytes(buf: ByteBuf) {
-		buf.writeLong(player!!.mostSignificantBits)
-		buf.writeLong(player!!.leastSignificantBits)
-		buf.writeInt(hand!!.ordinal)
-		ByteBufUtils.writeTag(buf, tag)
+		buf.writeBoolean(hand == EnumHand.MAIN_HAND)
+		var tasks = tasks!!
+		buf.writeShort(tasks.size)
+		for (task in tasks) {
+			ByteBufUtils.writeUTF8String(buf, task.task)
+			buf.writeBoolean(task.state)
+		}
 	}
 
 	override fun fromBytes(buf: ByteBuf) {
-		player = UUID(buf.readLong(), buf.readLong())
-		hand = EnumHand.values()[buf.readInt()]
-		tag = ByteBufUtils.readTag(buf)
+		hand = if (buf.readBoolean()) EnumHand.MAIN_HAND else EnumHand.OFF_HAND
+		var tasks = mutableListOf<Task>()
+		var count = buf.readShort()
+        while (count --> 0) {
+            tasks.add(Task(ByteBufUtils.readUTF8String(buf), buf.readBoolean()))
+        }
+        this.tasks = tasks
 	}
 
 }


### PR DESCRIPTION
Currently the clipboard item uses [PacketUpdateClipboard](https://github.com/shadowfacts/Clipboard/blob/9cea84241b87eb9c2b9137e822f8d745f723e52f/src/main/kotlin/net/shadowfacts/clipboard/network/PacketUpdateClipboard.kt) to send the itemstack's NBT with the modified task list to the server for synchronization. This can be exploited with a specially crafted packet to arbitrarily modify the NBT of any held item in either hand of any player connected to the server.

This PR resolves the issue by not having the client send its player entity id for player selection by the server, not sending the itemstack's NBT, and validating that the held item is the clipboard.

Arbitrary item creation can be achieved by holding a chest and sending the message with the NBT of a chest with items in it which can be retrieved by placing the chest.

I have created a [concept mod](https://gist.github.com/pau101/c5db69238f57c8c0f17f1734d592311c) which exploits the vulnerability. It sends an exploit packet which will fill a held chest with random items whenever the C key is pressed.

Aside from the vulnerability there should also be a limit on the number of tasks that can be on one clipboard since of the maximum payload size of 32767 will cause a failure to sync at a certain point. 

With the method of serialization I've implemented in this PR the max number of tasks is 334 with a max task text length of 32 characters.